### PR TITLE
Uses environment specific .condarc for channels

### DIFF
--- a/_sources/index.rst.txt
+++ b/_sources/index.rst.txt
@@ -89,9 +89,9 @@ found in the `defaults` channel.
 
 ::
 
-    conda config --add channels defaults
-    conda config --add channels bioconda
-    conda config --add channels conda-forge
+    conda config --env --add channels defaults
+    conda config --env --add channels bioconda
+    conda config --env --add channels conda-forge
 
 3. Install packages
 -------------------


### PR DESCRIPTION
Changed the commands for addition of the channels in the installation instructions so that it is specific to the active environment. This should help users who don't want to add those channels for their other environments or their base one.