### PR TITLE
Added instructions on how to use Gitpod for contributing.

### DIFF
--- a/_sources/contributor/gitpod.rst.txt
+++ b/_sources/contributor/gitpod.rst.txt
@@ -1,0 +1,58 @@
+Contribution using gitpod
++++++++++++++++++++++
+
+.. contents::
+   :local:
+   :backlinks: entry
+
+.. _open_gitpod:
+
+1. Open preconfigured Gitpod session
+~~~~~~~~~~~~~~~~~~
+
+To get started right away without needing to install any tools, you can launch a gitpod session
+on the following repository : ' bioconda_recipepod <https://github.com/FloWuenne/bioconda_recipepod>'.
+
+This will open a new Gitpod session with the following tools pre-installed:
+    - conda
+    - mamba
+    - grayskull
+    - bioconda-utils
+
+.. _create_branch:
+
+2. Create a branch in the bioconda-recipes folder
+~~~~~~~~~~~~~~~~~~
+
+The Gitpod environment by default enters a clone of the bioconda recipes repository, so you can directly get started with your recipe. Create a branch and either modify an existing recipe or create a new one using `conda skeleton` or `grayskull`.
+
+.. _lint_recipe:
+
+3. Lint your recipe
+~~~~~~~~~~~~~~~~~~
+
+To test if your recipe lints, run `bioconda-utils lint --git-range master` or `bioconda-utils lint --packages mypackage`.
+
+.. _test_recipe:
+
+4. Test your recipe
+~~~~~~~~~~~~~~~~~~
+
+To test if your recipe works, run `bioconda-utils build --docker --mulled-test --git-range master` or `bioconda-utils build --docker --mulled-test --packages mypackage`
+
+.. _add_fork:
+
+5. Add your fork as a remote
+~~~~~~~~~~~~~~~~~~
+
+Add your fork of bioconda recipes as a remote: `git remote add [name for your remote] [URL of your fork]`
+
+.. _push_to_remote:
+
+6. Push your changes to your fork
+~~~~~~~~~~~~~~~~~~
+
+Push your changes to your fork to open a Pull Request: `git push -u [name for your remote] [name of your branch]`
+
+
+That is it, your recipe should now be on your fork and branch for you to be able to open a pull request to the official bioconda recipes repo. 

--- a/_sources/contributor/index.rst.txt
+++ b/_sources/contributor/index.rst.txt
@@ -9,7 +9,7 @@ recipe you'd like to add.
 The basic workflow is:
 
 - Follow the :doc:`setup` instructions to get a local copy of the
-  recipes repository
+  recipes repository or use `Gitpod <https://www.gitpod.io/>` to develop your recipe in a preconfigured environment.
 
 - Write a recipe or modify an existing one. A recipe consists of a
   metadata file and (optionally) a shell script to install it. Here is
@@ -33,6 +33,7 @@ challenging to package. The topics below provide more details.
 
     setup
     workflow
+    gitpod
     building-locally
 
     troubleshooting


### PR DESCRIPTION
In the past, I was having issues developing bioconda recipes on Macbook M1 because of installation issues with M1 chips and sometimes just some package dependencies. 

I therefore developed a docker container, that contains all of the necessary tools to develop, lint and test bioconda recipes easily in the cloud using Gitpod (the docker container can also be used outside of Gitpod of course!).

To help people actually use this approach, [Phil Ewels ](https://github.com/ewels) suggested that I add some documentation to this repo on how to use this approach. 

I hope this can help more people quickly write and test recipes without having to setup anything really. 

Sorry if I didn't format anything not based on the template used for this page, but I wasn't sure what formatting is actually used to build this webage! If there are any changes or you want to put the Docker recipe somewhere in the official biodonconda space, no problem, just let me know 😊!